### PR TITLE
[f] Upgrade Python version from 3.9 to 3.11

### DIFF
--- a/.github/workflows/archive.yml
+++ b/.github/workflows/archive.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   CI: true
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.11
   PIPENV_VENV_IN_PROJECT: true
   SCRAPY_SETTINGS_MODULE: city_scrapers.settings.archive
   AUTOTHROTTLE_MAX_DELAY: 30.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        python-version: [3.9]
+        python-version: [3.11]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -7,7 +7,7 @@ on:
 
 env:
   CI: true
-  PYTHON_VERSION: 3.9
+  PYTHON_VERSION: 3.11
   PIPENV_VENV_IN_PROJECT: true
   SCRAPY_SETTINGS_MODULE: city_scrapers.settings.prod
   WAYBACK_ENABLED: true

--- a/Pipfile
+++ b/Pipfile
@@ -19,4 +19,4 @@ isort = "*"
 black = "*"
 
 [requires]
-python_version = "3.9"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -5,7 +5,7 @@
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.9"
+            "python_version": "3.11"
         },
         "sources": [
             {


### PR DESCRIPTION
## Description
- Upgrade Python version from 3.9 to 3.11 to resolve the conflict dependencies.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Upgraded Python version from 3.9 to 3.11 in the workflow configurations.

- **Bug Fixes**
	- No specific bug fixes were included in this release.

- **Documentation**
	- Updated environment variables and configurations to reflect the new Python version.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->